### PR TITLE
MOLGENIS 5.0.0 docker with Elasticsearch

### DIFF
--- a/molgenis/5.0/Dockerfile
+++ b/molgenis/5.0/Dockerfile
@@ -1,0 +1,21 @@
+FROM tomcat:7.0-jre8-alpine
+
+ARG MOLGENIS_VERSION
+
+# --no-cache allows users to install packages with an index that is updated and used on-the-fly and not cached locally
+# This avoids the need to use --update and remove /var/cache/apk/* when done installing packages.
+RUN apk --no-cache add openssl \	
+	&& wget -O molgenis-app-$MOLGENIS_VERSION.war https://oss.sonatype.org/content/repositories/snapshots/org/molgenis/molgenis-app/$MOLGENIS_VERSION/molgenis-app-5.0.0-20170620.011315-2.war
+
+RUN rm -r $CATALINA_HOME/webapps/ROOT \
+    && rm -r $CATALINA_HOME/webapps/docs \
+    && rm -r $CATALINA_HOME/webapps/examples \
+    && mv molgenis-app-$MOLGENIS_VERSION.war $CATALINA_HOME/webapps/ROOT.war \
+	&& echo 'CATALINA_OPTS="-Xmx2g -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -Dmolgenis.home=/opt/molgenis/"' > $CATALINA_HOME/bin/setenv.sh
+
+RUN mkdir -p /opt/molgenis \
+	&& if ! test -f /opt/molgenis/molgenis-server.properties; then echo -e "db_user=molgenis\ndb_password=molgenis\ndb_uri=jdbc\:postgresql\://db/molgenis?reWriteBatchedInserts\=true&autosave\=CONSERVATIVE\nadmin.password=admin\nelasticsearch.transport.addresses=elasticsearch:9300" > /opt/molgenis/molgenis-server.properties; fi
+
+VOLUME /opt/molgenis
+
+CMD ["catalina.sh", "run"]

--- a/molgenis/5.0/Dockerfile
+++ b/molgenis/5.0/Dockerfile
@@ -5,7 +5,7 @@ ARG MOLGENIS_VERSION
 # --no-cache allows users to install packages with an index that is updated and used on-the-fly and not cached locally
 # This avoids the need to use --update and remove /var/cache/apk/* when done installing packages.
 RUN apk --no-cache add openssl \	
-	&& wget -O molgenis-app-$MOLGENIS_VERSION.war https://oss.sonatype.org/content/repositories/snapshots/org/molgenis/molgenis-app/$MOLGENIS_VERSION/molgenis-app-5.0.0-20170620.011315-2.war
+	&& wget -O molgenis-app-$MOLGENIS_VERSION.war http://search.maven.org/remotecontent?filepath=org/molgenis/molgenis-app/$MOLGENIS_VERSION/molgenis-app-$MOLGENIS_VERSION.war
 
 RUN rm -r $CATALINA_HOME/webapps/ROOT \
     && rm -r $CATALINA_HOME/webapps/docs \

--- a/molgenis/5.0/docker-compose.yml
+++ b/molgenis/5.0/docker-compose.yml
@@ -1,0 +1,48 @@
+version: "3.0"
+services:
+    app:
+      build:
+          context: .
+          args:
+              - MOLGENIS_VERSION=5.0.0-SNAPSHOT
+      ports:
+        - "8081:8080"
+      links:
+        - db
+        - elasticsearch
+      volumes:
+        - app-data:/opt/molgenis
+      depends_on:
+        - elasticsearch
+    db:
+      image: postgres:9.6-alpine
+      environment:
+          - POSTGRES_USER=molgenis
+          - POSTGRES_PASSWORD=molgenis
+          - POSTGRES_DB=molgenis
+      expose:
+        - "5432"
+      volumes:
+        - db-data:/var/lib/postgresql/data
+    elasticsearch:
+        image: docker.elastic.co/elasticsearch/elasticsearch:5.4.1
+        container_name: elasticsearch
+        environment:
+          - cluster.name=molgenis
+          - bootstrap.memory_lock=true
+          - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+          - xpack.security.enabled=false
+        ulimits:
+          memlock:
+            soft: -1
+            hard: -1
+        volumes:
+          - es-data:/usr/share/elasticsearch/data
+        ports:
+          - 9200:9200
+          - 9300:9300
+volumes:
+    db-data:
+    app-data:
+    es-data:
+        driver: local

--- a/molgenis/5.0/docker-compose.yml
+++ b/molgenis/5.0/docker-compose.yml
@@ -4,7 +4,7 @@ services:
       build:
           context: .
           args:
-              - MOLGENIS_VERSION=5.0.0-SNAPSHOT
+              - MOLGENIS_VERSION=5.0.0
       ports:
         - "8081:8080"
       links:


### PR DESCRIPTION
Won't work until the MOLGENIS 5.0.0 artifacts are available in the Maven Central.