### PR TITLE
Feature/cgroups memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Docker
 Docker images for MOLGENIS applications.
 
+## Usage note
+Molgenis docker images are supplied for development and test purposes only. Currently this is not the suggested setup for running molgenis in production.
+
 ## Requirements
 - [Git](https://git-scm.com/downloads)
 - [Docker](https://www.docker.com/)

--- a/molgenis/5.1/app/Dockerfile
+++ b/molgenis/5.1/app/Dockerfile
@@ -11,7 +11,7 @@ RUN rm -r $CATALINA_HOME/webapps/ROOT \
     && rm -r $CATALINA_HOME/webapps/docs \
     && rm -r $CATALINA_HOME/webapps/examples \
     && mv molgenis-app-$MOLGENIS_VERSION.war $CATALINA_HOME/webapps/ROOT.war \
-	&& echo 'CATALINA_OPTS="-Xmx2g -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -Dmolgenis.home=/opt/molgenis/ -Dopencpu.uri.port=8004"' > $CATALINA_HOME/bin/setenv.sh
+	&& echo 'CATALINA_OPTS="-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -Dmolgenis.home=/opt/molgenis/ -Dopencpu.uri.port=8004"' > $CATALINA_HOME/bin/setenv.sh
 
 RUN mkdir -p /opt/molgenis \
 	&& if ! test -f /opt/molgenis/molgenis-server.properties; then echo -e "db_user=molgenis\ndb_password=molgenis\ndb_uri=jdbc\:postgresql\://db/molgenis\nadmin.password=admin\nelasticsearch.transport.addresses=elasticsearch:9300\nopencpu.uri.host=opencpu\npython_script_executable=/usr/bin/python3" > /opt/molgenis/molgenis-server.properties; fi


### PR DESCRIPTION
Use cgroups feature to have set memory constrains dynamically.

Is related to: https://github.com/molgenis/molgenis/issues/6612

background:
- The jvm running inside a docker container by default does not know it is running inside a container. As a result of this the jvm is not aware of the memory constrains set by the container manger. 
- As a result of the application by crash unexpectedly then it runs out of memory. 
- This pr sets a flag to have the jvm look at the available memory for the container.    
  